### PR TITLE
post検索→詳細　など

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  #before_action :set_current_user
+ # before_action :access_restriction
   
   def set_current_user
     @current_user = User.find_by(id: session[:user_id])
@@ -8,7 +8,9 @@ class ApplicationController < ActionController::Base
     if @current_user==nil
       redirect_to("/login")
   end
+ 
 
+  
   
  
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -22,7 +22,7 @@ class CompaniesController < ApplicationController
   end
   
   def show
-
+    @company = Company.find(id: session[:company_id])
   end
 
   def posts

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,6 +1,6 @@
 class CompaniesController < ApplicationController
 
-  before_action :set_company
+  before_action  :access_restriction, :set_company
 
   def index
     @companies = Company.all
@@ -56,8 +56,10 @@ private
 
  def set_company
 
-  if session[:company_id]
-    @company = Company.find_by(id: session[:company_id])
+  if @company.nil?
+     @company = Company.find_by(id: session[:company_id])
+  else
+     @company  
   end
   
  end
@@ -65,6 +67,19 @@ private
   
   def company_params
     params.permit(:name, :password, :place, :email, :profile)
+  end
+
+  def access_restriction
+    @url = request.referer
+    if @url ==nil
+      if session[:student_id]
+        redirect_to 'student_path'    
+      elsif session[:company_id]
+        redirect_to 'company_path'
+      else
+        redirect_to "/"  
+      end
+    end
   end
 
 

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -24,6 +24,10 @@ class CompaniesController < ApplicationController
   def show
 
   end
+
+  def posts
+  end
+
   
   def new
     render layout: "application_not_login"

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -22,7 +22,7 @@ class CompaniesController < ApplicationController
   end
   
   def show
-    @company = Company.find(id: session[:company_id])
+    @company = Company.find(params[:id]) #studentからの訪問用
   end
 
   def posts

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,23 @@
 class PostsController < ApplicationController
 
     def index 
-     @posts=Posts.all
+      logger
+     if params[:post]
+      if params[:post][:date]
+        @posts = @posts.where(date: params[:post][:date]);
+      end
+      
+   #   if params[:post][:place]
+    #    @posts = @posts.where('place like ?', "%#{params[:post][:place]}%");
+   #   end
+
+    #  if params[:post][:mxpeople]
+     #   @posts = @posts.where("mxpeople > ?", params[:post][:mxpeople]);
+     # end
+     else
+      @posts = Post.all
+     end
+
     end
 
     def new
@@ -9,12 +25,10 @@ class PostsController < ApplicationController
     end
 
     def show
-
     end
 
     def create
-      logger.debug post_params
-      logger.debug 'Aaaaaaaaaaaaa'
+      
       @post=Post.new(post_params)
       if @post.save!
          #@company= Company.find_by(id: session[:company_id])

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,6 +30,8 @@ class PostsController < ApplicationController
     end
 
     def show
+      @post = Post.find(params[:id])
+      @company = Company.find_by(id: @post.company_id)
     end
 
     def create

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,19 +1,24 @@
 class PostsController < ApplicationController
 
     def index 
-      logger
+      
+
      if params[:post]
-      if params[:post][:date]
+      @posts = Post.all
+      if params[:post][:date] && params[:post][:date]!= ""
         @posts = @posts.where(date: params[:post][:date]);
+        
       end
       
-   #   if params[:post][:place]
-    #    @posts = @posts.where('place like ?', "%#{params[:post][:place]}%");
-   #   end
+      if params[:post][:place] && params[:post][:place]!= ""
+        @posts = @posts.where('place like ?', "%#{params[:post][:place]}%");
+        
+      end
 
-    #  if params[:post][:mxpeople]
-     #   @posts = @posts.where("mxpeople > ?", params[:post][:mxpeople]);
-     # end
+      if params[:post][:mxpeople] && params[:post][:mxpeople]!= ""
+        @posts = @posts.where("mxpeople >= ?", params[:post][:mxpeople]);
+           
+      end
      else
       @posts = Post.all
      end

--- a/app/views/companies/posts.html.erb
+++ b/app/views/companies/posts.html.erb
@@ -1,6 +1,17 @@
 <div class="container">
-<% if @company.posts? %>
-  <p>上手くいった！</p>
+<% if @company.posts.length >0 %>
+  <%= @company.posts.each do |p| %>
+    <ul>
+      <a href="/posts/<%=p.id %>">
+       <li>
+        <p><%= p.date%></p>
+        <p><%= p.place%></p>
+        <p><%= p.requirement%></p>
+       </li>
+      </a>
+    </ul>
+  <% end %>
+  <!--謎表記聞く-->
  
 <% else %>
 　<p>まだ掲載情報がありません</p>

--- a/app/views/companies/posts.html.erb
+++ b/app/views/companies/posts.html.erb
@@ -1,0 +1,8 @@
+<div class="container">
+<% if @company.posts? %>
+  <p>上手くいった！</p>
+ 
+<% else %>
+　<p>まだ掲載情報がありません</p>
+<% end %>
+</div>

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -1,4 +1,5 @@
 <div class="container-fluid">
+<% if session[:company_id] %>
  <div class="row">
    <div class="col col-md-2">
      <ul class="list-unstyled">
@@ -9,6 +10,7 @@
      </ul>
    </div>
  </div>
+<% end %> 
 </div>
 
 <div class="container text-center">

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -2,10 +2,10 @@
  <div class="row">
    <div class="col col-md-2">
      <ul class="list-unstyled">
-       <li><a href="#">検索する</a></li>
+       <li><a href="/posts">検索する</a></li>
        <li><a href="/posts/new">掲載する</a></li>
        <li><a href="#">メッセージ</a></li>
-       <li><a href="#">掲載履歴</a></li>
+       <li><a href="posts">掲載履歴</a></li>
      </ul>
    </div>
  </div>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,4 +1,4 @@
-<div class="container text-center pt-4">
+<div class="container text-center">
   <h1>みんなのへや</h1>
   <p>企業と若者を「オフィス」で結ぶ</p>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,11 +40,11 @@
 
             <a href="" class="nav-item nav-link">検索する</a>
 
-            <%= link_to "マイページ", "company_path" %>
+            <%= link_to "マイページ" %>
             
             <a href="" class="nav-item nav-link">お問い合せ</a>
 
-            <%=link_to("ログアウト","/")%>
+            <%=link_to "ログアウト","/" %>
 
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,6 +41,7 @@
             <a href="" class="nav-item nav-link">検索する</a>
 
             <%= link_to "マイページ", "company_path" %>
+            
             <a href="" class="nav-item nav-link">お問い合せ</a>
 
             <%=link_to("ログアウト","/")%>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,7 @@
 
 <%= form_for Post.new, url: posts_path, method: 'get' do |p| %>
  <div class="form-group">
-    <%= p.date_select :date, class: 'form-control', placeholder: "日付" %>
+    <%= p.date_field :date, class: 'form-control', placeholder: "日付" %>
  </div>
  
  <div class="form-group">
@@ -14,6 +14,7 @@
  
   <%= p.submit '検索' %>
 <% end %>
+<%= link_to "検索条件をクリア", posts_path %>
 
 
 <ul>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,28 @@
+
+<%= form_for Post.new, url: posts_path, method: 'get' do |p| %>
+ <div class="form-group">
+    <%= p.date_select :date, class: 'form-control', placeholder: "日付" %>
+ </div>
+ 
+ <div class="form-group">
+    <%= p.text_field :place, class: 'form-control', placeholder: "場所" %>
+ </div>
+
+ <div class="form-group">
+    <%= p.number_field :mxpeople, class: 'form-control', placeholder: "最大人数" %>
+ </div>
+ 
+  <%= p.submit '検索' %>
+<% end %>
+
+
+<ul>
+ <% @posts.each do |p| %>
+  <a href = "#"><li>
+    <p><%= p.place%></p><br>
+    <p><%= p.date%></p><br>
+    <p><%= p.mxpeople%>人</p><br>
+  </li></a>
+  <hr>
+  <% end %>
+</ul>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -19,7 +19,7 @@
 
 <ul>
  <% @posts.each do |p| %>
-  <a href = "#"><li>
+  <a href = "/posts/<%= p.id %>"><li>
     <p><%= p.place%></p><br>
     <p><%= p.date%></p><br>
     <p><%= p.mxpeople%>人</p><br>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,17 @@
+<div class="container">
+ <p><%= @post.date %></p>
+ 
+ <p><%= @post.place %></p>
+
+ <p><%= @post.requirement %></p>
+
+ <p><%= @post.detail %></p>
+
+ <% if session[:student_id]%>
+  <p>掲載会社: <a href = "/companies/<%=@company.id%>"><%= @company.name %></a></p>
+ <% else %>
+  <p>掲載会社:<%= @company.name %></p>
+ <% end %>
+
+
+</div>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -2,7 +2,7 @@
  <div class="row">
    <div class="col col-md-2">
      <ul class="list-unstyled">
-       <li><a href="#">検索する</a></li>
+       <li><a href="/posts">検索する</a></li>
        <li><a href="#">メッセージ</a></li>
        <li><a href="#">応募履歴</a></li>
      </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   get '/companies/login_form', to:'companies#login_form'
   post '/companies/login', to:'companies#login'
+  get '/companies/posts', to: 'companies#posts'
   resources :companies
   
 


### PR DESCRIPTION
・post一覧検索ページから、そのリンク先のpost/showページ作成、そこから学生限定での掲載企業のshowへのリンクとその遷移

・companyのマイページから掲載一覧とその詳細表示ページ作成（一部謎表記エラー）

・学生がpostのshowページから企業のshowページにアクセスできるようになったため、sessionの種類によって表示内容を変える処理（別ブランチで進行中のprofileのeditへのリンクもあとでsessionによって表示を隠すように書き換える必要あり）